### PR TITLE
Add silentpayments logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ dnssec-prover = { version = "0.6", default-features = false, optional = true, fe
 reqwest = { version = "0.11", default-features = false, optional = true, features = ["rustls-tls-webpki-roots", "json"] }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }
+silentpayments = "0.4.1"
 
 [dev-dependencies]
 tokio = { version = "1.0", default-features = false, features = ["rt", "macros"] }

--- a/src/dns_resolver.rs
+++ b/src/dns_resolver.rs
@@ -99,6 +99,7 @@ mod tests {
 				},
 				PaymentMethod::LightningBolt12(_) => {},
 				PaymentMethod::OnChain { .. } => {},
+				PaymentMethod::SilentPayment { .. } => {},
 			}
 		}
 	}

--- a/src/hrn_resolution.rs
+++ b/src/hrn_resolution.rs
@@ -19,6 +19,7 @@ use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+#[derive(Debug)]
 /// The first-step resolution of a Human Readable Name.
 ///
 /// It can either represent a resolution using BIP 353 and the DNS or the first step resolution of

--- a/src/onion_message_resolver.rs
+++ b/src/onion_message_resolver.rs
@@ -421,6 +421,7 @@ mod tests {
 				},
 				PaymentMethod::LightningBolt12(_) => {},
 				PaymentMethod::OnChain { .. } => {},
+				PaymentMethod::SilentPayment(_) => {},
 			}
 		}
 	}


### PR DESCRIPTION
I needed to parse Silent Payments address inscribed in DNS record according to the BIP353 specification, I think that's rather straightforward the only thing I'm not quite sure of is support for testnet/signet sp addresses. Opening it as a draft for now 