### PR TITLE
Replace reqwest with bitreq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
           cd fuzz
           cargo update -p syn --precise "2.0.106" --verbose
           cargo update -p quote --precise "1.0.41" --verbose
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose
           RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz" cargo test --verbose --color always
           cargo clean
       - name: Run fuzzers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-payment-instructions"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Matt Corallo", "Ben Carman"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-bitcoin/bitcoin-payment-instructions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ features = ["std", "http"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-http = ["reqwest", "std", "serde", "serde_json"]
+http = ["bitreq", "std", "serde", "serde_json"]
+http_proxied = [ "http", "bitreq/proxy" ]
 std = ["dnssec-prover", "getrandom"]
 default = ["std"]
 
@@ -24,7 +25,7 @@ lightning = { version = "0.2.0", default-features = false, features = ["dnssec"]
 bitcoin = { version = "0.32", default-features = false }
 getrandom = { version = "0.3", default-features = false, optional = true }
 dnssec-prover = { version = "0.6", default-features = false, optional = true, features = ["validation", "std", "tokio"] }
-reqwest = { version = "0.11", default-features = false, optional = true, features = ["rustls-tls-webpki-roots", "json"] }
+bitreq = { version = "0.2", default-features = false, optional = true, features = [ "async-https" ] }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["alloc"] }
 

--- a/ci/check-lint.sh
+++ b/ci/check-lint.sh
@@ -6,7 +6,6 @@ RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
 
 # Starting with version 1.39.0, the `tokio` crate has an MSRV of rustc 1.70.0
 [ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p tokio --precise "1.38.1" --verbose
-[ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p tokio-util --precise "0.7.10" --verbose
 
 # syn 2.0.107 requires rustc 1.68.0
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p syn --precise "2.0.106" --verbose

--- a/ci/check-lint.sh
+++ b/ci/check-lint.sh
@@ -11,6 +11,8 @@ RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p syn --precise "2.0.106" --verbose
 # quote 1.0.42 requires rustc 1.68.0
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p quote --precise "1.0.41" --verbose
+# Starting with version 1.0.104, the `proc-macro2` crate has an MSRV of rustc 1.68
+[ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p proc-macro2 --precise "1.0.103" --verbose
 
 RUSTFLAGS='-D warnings' cargo clippy -- \
 	`# We use this for sat groupings` \

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -5,7 +5,6 @@ RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
 
 # Starting with version 1.39.0, the `tokio` crate has an MSRV of rustc 1.70.0
 [ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p tokio --precise "1.38.1" --verbose
-[ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p tokio-util --precise "0.7.10" --verbose
 
 # syn 2.0.107 requires rustc 1.68.0
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p syn --precise "2.0.106" --verbose
@@ -18,10 +17,9 @@ cargo check --verbose --color always
 cargo check --release --verbose --color always
 cargo test --no-default-features
 [ "$RUSTC_MINOR_VERSION" -gt 81 ] && cargo test --features http
-# One std test syncs much of the lightning network graph, so --release is a must
-# At least until https://github.com/lightningdevkit/rust-lightning/pull/3687 gets backported
-export RUSTFLAGS="-C debug-assertions=on"
+[ "$RUSTC_MINOR_VERSION" -gt 81 ] && cargo test --features http_proxied
 cargo test --features std --release
 [ "$RUSTC_MINOR_VERSION" -gt 81 ] && cargo doc --document-private-items --no-default-features
 [ "$RUSTC_MINOR_VERSION" -gt 81 ] && cargo doc --document-private-items --features http,std
+[ "$RUSTC_MINOR_VERSION" -gt 81 ] && cargo doc --document-private-items --features http_proxied,std
 exit 0

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -10,6 +10,17 @@ RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p syn --precise "2.0.106" --verbose
 # quote 1.0.42 requires rustc 1.68.0
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p quote --precise "1.0.41" --verbose
+# Starting with version 1.0.104, the `proc-macro2` crate has an MSRV of rustc 1.68
+[ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p proc-macro2 --precise "1.0.103" --verbose
+
+# Starting with version 2.0.107, the `syn` crate has an MSRV of rustc 1.68
+[ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p syn --precise "2.0.106" --verbose
+
+# Starting with version 1.0.42, the `quote` crate has an MSRV of rustc 1.68
+[ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p quote --precise "1.0.41" --verbose
+
+# Starting with version 1.0.104, the `proc-macro2` crate has an MSRV of rustc 1.68
+[ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p proc-macro2 --precise "1.0.103" --verbose
 
 export RUST_BACKTRACE=1
 


### PR DESCRIPTION
`reqwest` has an absolutely insane dependency tree, with
anti-features (like insanely-fast-unsafe-IDN parsing) baked in.
Instead, the rust-bitcoin ecosystem is starting to move to `bitreq`
which is relatively simple, only depends (even optionally) on
`tokio` and `rustls`, and doesn't bother with crap like IDNs.

Here we switch over, maintaining the ability to proxy connections
for those that need that.