### PR TITLE
Fix on-chain amount rounding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,10 +95,23 @@ jobs:
       - name: Sanity check fuzz targets on Rust ${{ env.TOOLCHAIN }}
         run: |
           cd fuzz
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cargo update -p libc --precise "0.2.183" --verbose
           cargo update -p syn --precise "2.0.106" --verbose
           cargo update -p quote --precise "1.0.41" --verbose
           cargo update -p proc-macro2 --precise "1.0.103" --verbose
+          cargo update -p honggfuzz --precise "0.5.59" --verbose
+          cargo update -p semver --precise "1.0.27" --verbose
           RUSTFLAGS="--cfg=fuzzing --cfg=secp256k1_fuzz --cfg=hashes_fuzz" cargo test --verbose --color always
           cargo clean
       - name: Run fuzzers
-        run: cd fuzz && ./ci-fuzz.sh && cd ..
+        run: |
+          cd fuzz
+          cargo update -p unicode-ident --precise "1.0.22" --verbose
+          cargo update -p libc --precise "0.2.183" --verbose
+          cargo update -p syn --precise "2.0.106" --verbose
+          cargo update -p quote --precise "1.0.41" --verbose
+          cargo update -p proc-macro2 --precise "1.0.103" --verbose
+          cargo update -p honggfuzz --precise "0.5.59" --verbose
+          cargo update -p semver --precise "1.0.27" --verbose
+          ./ci-fuzz.sh

--- a/ci/check-lint.sh
+++ b/ci/check-lint.sh
@@ -7,6 +7,12 @@ RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
 # Starting with version 1.39.0, the `tokio` crate has an MSRV of rustc 1.70.0
 [ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p tokio --precise "1.38.1" --verbose
 
+# unicode-ident 1.0.23 requires rustc 1.71.0
+cargo update -p unicode-ident --precise "1.0.22" --verbose
+
+# libc 0.2.184 requires rustc 1.65.0
+cargo update -p libc --precise "0.2.183" --verbose
+
 # syn 2.0.107 requires rustc 1.68.0
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p syn --precise "2.0.106" --verbose
 # quote 1.0.42 requires rustc 1.68.0

--- a/ci/ci-tests.sh
+++ b/ci/ci-tests.sh
@@ -6,6 +6,12 @@ RUSTC_MINOR_VERSION=$(rustc --version | awk '{ split($2,a,"."); print a[2] }')
 # Starting with version 1.39.0, the `tokio` crate has an MSRV of rustc 1.70.0
 [ "$RUSTC_MINOR_VERSION" -lt 70 ] && cargo update -p tokio --precise "1.38.1" --verbose
 
+# unicode-ident 1.0.23 requires rustc 1.71.0
+cargo update -p unicode-ident --precise "1.0.22" --verbose
+
+# libc 0.2.184 requires rustc 1.65.0
+cargo update -p libc --precise "0.2.183" --verbose
+
 # syn 2.0.107 requires rustc 1.68.0
 [ "$RUSTC_MINOR_VERSION" -lt 68 ] && cargo update -p syn --precise "2.0.106" --verbose
 # quote 1.0.42 requires rustc 1.68.0

--- a/fuzz/ci-fuzz.sh
+++ b/fuzz/ci-fuzz.sh
@@ -8,7 +8,7 @@ rm *_target.rs
 [ "$(git diff)" != "" ] && exit 1
 popd
 
-cargo install --color always --force honggfuzz --no-default-features
+cargo install --color always --force honggfuzz --version 0.5.59 --no-default-features
 sed -i 's/lto = true//' Cargo.toml
 
 export RUSTFLAGS="--cfg=secp256k1_fuzz --cfg=hashes_fuzz"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,7 @@ impl ConfigurableAmountPaymentInstructions {
 			inner.ln_amt = Some(amount);
 		} else {
 			if inner.methods.iter().any(|meth| matches!(meth, PaymentMethod::OnChain(_))) {
-				let amt = Amount::from_milli_sats((amount.milli_sats() + 999) / 1000)
+				let amt = Amount::from_sats((amount.milli_sats() + 999) / 1000)
 					.map_err(|_| "Requested amount was too close to 21M sats to round up")?;
 				inner.onchain_amt = Some(amt);
 			}
@@ -1207,17 +1207,20 @@ mod tests {
 
 		assert_eq!(parsed.recipient_description(), None);
 
+		let amount = Amount::from_sats(10_000).unwrap();
+
 		let resolved = match parsed {
 			PaymentInstructions::ConfigurableAmount(parsed) => {
 				assert_eq!(parsed.min_amt(), None);
 				assert_eq!(parsed.min_amt(), None);
 				assert_eq!(parsed.methods().collect::<Vec<_>>().len(), 1);
-				parsed.set_amount(Amount::from_sats(10).unwrap(), &DummyHrnResolver).await.unwrap()
+				parsed.set_amount(amount, &DummyHrnResolver).await.unwrap()
 			},
 			_ => panic!(),
 		};
 
 		assert_eq!(resolved.methods().len(), 1);
+		assert_eq!(resolved.onchain_payment_amount(), Some(amount));
 		if let PaymentMethod::OnChain(address) = &resolved.methods()[0] {
 			assert_eq!(*address, Address::from_str(addr_str).unwrap().assume_checked());
 		} else {


### PR DESCRIPTION
The configurable amount path rounded millisats up to whole sats but then constructed the result as millisats. Fix the bug by building the rounded value as sats so on-chain fixed-amount instructions has the correct amount. Added a test to find regressions.